### PR TITLE
fix: Add a GitHub CI workflow and README badge (#57)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [ 12.x, 14.x, 15.x ]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    # - run: npm test

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+[![Node.js CI][ci-badge]][ci]
+
 # Cookieconsent Script
 
 A script that displays a cookie consent message as required by EU regulation (GDPR). The plugin displays a message on the user's first visit and they have the ability to consent to different categories of cookies and services.
@@ -160,3 +162,6 @@ The script is being controlled mainly by a configuration object which is passed 
   });
   </script>
 ```
+
+[ci-badge]: https://github.com/brainsum/cookieconsent/actions/workflows/nodejs.yml/badge.svg
+[ci]: https://github.com/brainsum/cookieconsent/actions/workflows/nodejs.yml


### PR DESCRIPTION
Hi,

As proposed in #57, here is a pull request adding a basic _Continuous Integration_ workflow.

* [Node.js versions](https://nodejs.org/en/about/releases/) :~ 12.x, 14.x, 15.x;
* Note, for the moment I've commented out the `npm test` line ;)
* Relates to: #56.


Nick


---

 * [x]  — Workflow `.github/workflows/nodejs.yml`;
 * [x]  — Badge in the README;
